### PR TITLE
Add access control by checking if Teams tenant matches appservice tenant

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -64,6 +64,8 @@ param keyVaultLocation string = resourceGroup().location
 @description('Location to deploy Managed Identity')
 param msiLocation string = resourceGroup().location
 param storageAccountLocation string = resourceGroup().location
+@description('By default, the AppService will only allow Teams users from the same tenant. This parameter allows you to specify additional tenant IDs to allow access to the AppService. This is a comma-separated list of tenant IDs.')
+param additionalAllowedTenantIds string
 
 @description('Alternative GPT model endpoint. This only affects the reasoning model')
 param aiEndpointReasoningOverride string = ''
@@ -387,7 +389,8 @@ module m_app 'modules/appservice.bicep' = {
     fhirServiceEndpoint: fhirServiceEndpoint
     fabricUserDataFunctionEndpoint: fabricUserDataFunctionEndpoint
     appServiceSubnetId: m_network.outputs.appServiceSubnetId
-    additionalAllowedIps: additionalAllowedIps 
+    additionalAllowedIps: additionalAllowedIps
+    additionalAllowedTenantIds: additionalAllowedTenantIds
   }
 }
 

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -65,7 +65,7 @@ param keyVaultLocation string = resourceGroup().location
 param msiLocation string = resourceGroup().location
 param storageAccountLocation string = resourceGroup().location
 @description('By default, the AppService will only allow Teams users from the same tenant. This parameter allows you to specify additional tenant IDs to allow access to the AppService. This is a comma-separated list of tenant IDs.')
-param additionalAllowedTenantIds string
+param additionalAllowedTenantIds string = ''
 
 @description('Alternative GPT model endpoint. This only affects the reasoning model')
 param aiEndpointReasoningOverride string = ''

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -357,8 +357,8 @@ module m_fhirService 'modules/fhirService.bicep' = if (shouldDeployFhirService) 
   }
 }
 
-var outHlsModelEndpoints = hasHlsModelEndpoints ? hlsModelEndpoints : toObject(hlsModels.outputs.modelEndpoints, model => model.name, model => model.endpoint)
-var outFhirServiceEndpoint = shouldDeployFhirService ? m_fhirService.outputs.endpoint : fhirServiceEndpoint
+var outHlsModelEndpoints = hasHlsModelEndpoints ? hlsModelEndpoints : toObject(hlsModels!.outputs.modelEndpoints, model => model.name, model => model.endpoint)
+var outFhirServiceEndpoint = shouldDeployFhirService ? m_fhirService!.outputs.endpoint : fhirServiceEndpoint
 
 module m_app 'modules/appservice.bicep' = {
   name: 'deploy_app'
@@ -446,7 +446,7 @@ output FHIR_SERVICE_ENDPOINT string = outFhirServiceEndpoint
 output FABRIC_USER_DATA_FUNCTION_ENDPOINT string = fabricUserDataFunctionEndpoint
 output HLS_MODEL_ENDPOINTS string = string(outHlsModelEndpoints)
 output KEYVAULT_ENDPOINT string = m_keyVault.outputs.keyVaultEndpoint
-output HEALTHCARE_AGENT_SERVICE_ENDPOINTS array = !empty(healthcareAgents) ? m_healthcareAgentService.outputs.healthcareAgentServiceEndpoints : []
+output HEALTHCARE_AGENT_SERVICE_ENDPOINTS array = !empty(healthcareAgents) ? m_healthcareAgentService!.outputs.healthcareAgentServiceEndpoints : []
 output VNET_ID string = m_network.outputs.vnetId
 output VNET_NAME string = m_network.outputs.vnetName
 output APP_SERVICE_SUBNET_ID string = m_network.outputs.appServiceSubnetId

--- a/infra/main.parameters.json
+++ b/infra/main.parameters.json
@@ -88,6 +88,9 @@
     "additionalAllowedIps": {
       "value": "${ADDITIONAL_ALLOWED_IPS}"
     },
+    "additionalAllowedTenantIds": {
+      "value": "${ADDITIONAL_ALLOWED_TENANT_IDS}"
+    },
     "graphRagSubscriptionKey": {
       "value": "${GRAPH_RAG_SUBSCRIPTION_KEY}"
     },

--- a/infra/modules/appservice.bicep
+++ b/infra/modules/appservice.bicep
@@ -23,7 +23,7 @@ param fhirServiceEndpoint string = ''
 param fabricUserDataFunctionEndpoint string = ''
 param appServiceSubnetId string
 param additionalAllowedIps string = ''
-
+param additionalAllowedTenantIds string = ''
 
 var botIdsArray = [
   for (msi, index) in msis: {
@@ -173,6 +173,7 @@ resource backEndNameSiteConfig 'Microsoft.Web/sites/config@2024-04-01' = {
     MicrosoftAppType: 'UserAssignedMSI'
     AZURE_CLIENT_ID: msis[0].msiClientID
     MicrosoftAppTenantId: tenant().tenantId
+    ADDITIONAL_ALLOWED_TENANT_IDS: additionalAllowedTenantIds
     AZURE_AI_PROJECT_CONNECTION_STRING: '${split(aiProject.properties.discoveryUrl, '/')[2]};${subscription().subscriptionId};${resourceGroup().name};${aiProjectName}'
     AZURE_OPENAI_API_ENDPOINT: openaiEnpoint
     AZURE_OPENAI_ENDPOINT: openaiEnpoint

--- a/src/bots/access_control_middleware.py
+++ b/src/bots/access_control_middleware.py
@@ -25,10 +25,6 @@ class AccessControlMiddleware(Middleware):
         if context.activity.type not in [ActivityTypes.message, ActivityTypes.installation_update]:
             return await logic(context)
 
-        app_tenant_id = os.getenv("MicrosoftAppTenantId")
-        if app_tenant_id is None:
-            raise ValueError("MicrosoftAppTenantId environment variable is not set.")
-
         # Check if the activity is from Teams channel
         if context.activity.channel_id == Channels.ms_teams:
             channel_data = TeamsChannelData().deserialize(
@@ -38,7 +34,7 @@ class AccessControlMiddleware(Middleware):
             # Check if the turn context's activity has a tenant ID
             if channel_data and channel_data.tenant and channel_data.tenant.id:
                 tenant_id = channel_data.tenant.id
-                if tenant_id == app_tenant_id:
+                if tenant_id in self._get_allowed_tenant_ids():
                     return await logic()
                 else:
                     raise NotAuthorizedError(
@@ -50,3 +46,25 @@ class AccessControlMiddleware(Middleware):
             raise NotAuthorizedError(
                 f"Activity is not from Teams channel. Channel ID: {context.activity.channel_id}"
             )
+
+    @staticmethod
+    def _get_allowed_tenant_ids() -> list[str]:
+        """
+        Retrieve additional allowed tenant IDs from environment variable.
+        This is a comma-separated list of tenant IDs.
+        """
+        # Get the app's tenant ID
+        app_tenant_id = os.getenv("MicrosoftAppTenantId")
+        if app_tenant_id is None:
+            raise ValueError("MicrosoftAppTenantId environment variable is not set.")
+
+        # Always allow the app's tenant ID
+        allowed_tenant_ids = [app_tenant_id]
+
+        # Retrieve additional allowed tenant IDs from environment variable
+        additional_allowed_tenant_ids = os.getenv("ADDITIONAL_ALLOWED_TENANT_IDS")
+        if additional_allowed_tenant_ids:
+            allowed_tenant_ids.extend([tenant.strip() for tenant in additional_allowed_tenant_ids.split(",")])
+        logger.debug(f"Allowed tenant IDs: {allowed_tenant_ids}")
+
+        return allowed_tenant_ids

--- a/src/bots/access_control_middleware.py
+++ b/src/bots/access_control_middleware.py
@@ -1,0 +1,52 @@
+import logging
+import os
+from typing import Awaitable, Callable
+
+from botbuilder.core import Middleware, TurnContext
+from botbuilder.schema import ActivityTypes
+from botbuilder.schema.teams import TeamsChannelData
+from botframework.connector import Channels
+
+from errors import NotAuthorizedError
+
+logger = logging.getLogger(__name__)
+
+
+class AccessControlMiddleware(Middleware):
+    """
+    Middleware to enforce access control based on tenant ID for Teams channel.
+    https://learn.microsoft.com/en-us/azure/bot-service/bot-service-resources-faq-security?view=azure-bot-service-4.0
+    """
+
+    async def on_turn(
+        self, context: TurnContext, logic: Callable[[TurnContext], Awaitable]
+    ):
+        # Skip middleware for non-message activities or installation updates
+        if context.activity.type not in [ActivityTypes.message, ActivityTypes.installation_update]:
+            return await logic(context)
+
+        app_tenant_id = os.getenv("MicrosoftAppTenantId")
+        if app_tenant_id is None:
+            raise ValueError("MicrosoftAppTenantId environment variable is not set.")
+
+        # Check if the activity is from Teams channel
+        if context.activity.channel_id == Channels.ms_teams:
+            channel_data = TeamsChannelData().deserialize(
+                context.activity.channel_data
+            )
+
+            # Check if the turn context's activity has a tenant ID
+            if channel_data and channel_data.tenant and channel_data.tenant.id:
+                tenant_id = channel_data.tenant.id
+                if tenant_id == app_tenant_id:
+                    return await logic()
+                else:
+                    raise NotAuthorizedError(
+                        f"Access denied for tenant {tenant_id}."
+                    )
+            else:
+                raise NotAuthorizedError("No tenant ID found in channel data.")
+        else:
+            raise NotAuthorizedError(
+                f"Activity is not from Teams channel. Channel ID: {context.activity.channel_id}"
+            )

--- a/src/bots/assistant_bot.py
+++ b/src/bots/assistant_bot.py
@@ -4,12 +4,11 @@
 import asyncio
 import logging
 import os
-from typing import List
 
 from botbuilder.core import MessageFactory, TurnContext
 from botbuilder.core.teams import TeamsActivityHandler
 from botbuilder.integration.aiohttp import CloudAdapter
-from botbuilder.schema import Activity, ActivityTypes, ChannelAccount
+from botbuilder.schema import Activity, ActivityTypes
 from semantic_kernel.agents import AgentGroupChat
 
 from data_models.app_context import AppContext
@@ -84,18 +83,6 @@ class AssistantBot(TeamsActivityHandler):
         context.turn_state[CloudAdapter.BOT_CALLBACK_HANDLER_KEY] = logic
 
         return context
-
-    async def on_members_added_activity(
-        self, members_added: List[ChannelAccount], turn_context: TurnContext
-    ):
-        logger.info(
-            f"recipient_id: {turn_context.activity.recipient.id}, members_added: {[member.id for member in members_added]}")
-
-        for member in members_added:
-            if member.id != turn_context.activity.recipient.id:
-                # If the bot is added to a group chat, send a welcome message
-                welcome_message = f"Hello! I am {self.name}. How can I assist you today?"
-                await turn_context.send_activity(MessageFactory.text(welcome_message))
 
     async def on_message_activity(self, turn_context: TurnContext) -> None:
         conversation_id = turn_context.activity.conversation.id

--- a/src/errors.py
+++ b/src/errors.py
@@ -1,0 +1,3 @@
+class NotAuthorizedError(Exception):
+    """Exception raised for unauthorized access attempts."""
+    pass

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,10 +1,11 @@
-aiohttp==3.9.5
+aiohttp==3.12.14
 aiohttp-compress==0.2.1
 azure-core==1.31.0
 azure-identity==1.19.0
 azure-storage-blob==12.25.0
-botbuilder-core==4.16.1
-botbuilder-integration-aiohttp==4.16.1
+botbuilder-core==4.17.0
+botbuilder-dialogs==4.17.0
+botbuilder-integration-aiohttp==4.17.0
 python-dotenv==1.0.1
 semantic-kernel==1.20.0
 numpy==1.26.4

--- a/src/routes/api/messages.py
+++ b/src/routes/api/messages.py
@@ -24,11 +24,13 @@ def create_router(botName: str, bot: AssistantBot, adapter: CloudAdapter, router
             if "Authorization" in request.headers
             else ""
         )
+        logger.info(f"Received message for bot {botName}. headers: {request.headers}, body: {body}")
 
         # add explicit auth check
         authentication_result = await adapter.bot_framework_authentication.authenticate_request(
             activity, auth_header
         )
+        logger.info(f"Authentication result: {{ audience: {authentication_result.audience}, claims: {authentication_result.claims_identity.claims}, authenticated: {authentication_result.claims_identity.is_authenticated}, auth_type: {authentication_result.claims_identity.authentication_type}, caller_id: {authentication_result.caller_id} }}")
 
         if not authentication_result or not authentication_result.claims_identity.is_authenticated:
             # Optionally could check the aud claim to make sure it matches the requested bot. Though I am fairly certain this is already done in the adapter.

--- a/src/routes/api/messages.py
+++ b/src/routes/api/messages.py
@@ -24,13 +24,11 @@ def create_router(botName: str, bot: AssistantBot, adapter: CloudAdapter, router
             if "Authorization" in request.headers
             else ""
         )
-        logger.info(f"Received message for bot {botName}. headers: {request.headers}, body: {body}")
 
         # add explicit auth check
         authentication_result = await adapter.bot_framework_authentication.authenticate_request(
             activity, auth_header
         )
-        logger.info(f"Authentication result: {{ audience: {authentication_result.audience}, claims: {authentication_result.claims_identity.claims}, authenticated: {authentication_result.claims_identity.is_authenticated}, auth_type: {authentication_result.claims_identity.authentication_type}, caller_id: {authentication_result.caller_id} }}")
 
         if not authentication_result or not authentication_result.claims_identity.is_authenticated:
             # Optionally could check the aud claim to make sure it matches the requested bot. Though I am fairly certain this is already done in the adapter.


### PR DESCRIPTION
## Purpose
Restrict access to appservice for users from a list of approved tenants.  By default, users from the same tenant as the appservice is always allowed.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## Test the code
`ADDITIONAL_ALLOWED_TENANT_IDS` not set.  Users from the same tenant should be allowed.

<img width="749" height="108" alt="image" src="https://github.com/user-attachments/assets/ad1350e4-a756-453d-bbf7-5b37fbd5e57b" />

Users from other tenants should be blocked:

<img width="739" height="94" alt="image" src="https://github.com/user-attachments/assets/f0425749-d6e8-4dc0-b9f9-c6a74f4b5f46" />

`ADDITIONAL_ALLOWED_TENANT_IDS` is set.  Users from the same tenant should be allowed.

<img width="749" height="108" alt="image" src="https://github.com/user-attachments/assets/ad1350e4-a756-453d-bbf7-5b37fbd5e57b" />

Users from other tenants should now be allowed:

<img width="751" height="103" alt="image" src="https://github.com/user-attachments/assets/cdf59a87-ac53-4634-abc8-1d9e0fa9d3d1" />