### PR TITLE
Fixed vnet/subnet redeployment issue with additional ip addition

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,8 @@ As part of the deployment, a simple chat UI was also deployed. You can access it
 > azd env set ADDITIONAL_ALLOWED_IPS "your.ip.address/32"
 > azd up
 > ```
+> **Important**: You need to add your own IP address if you want to access grounded links and generated Word documents from the healthcare agents.
+> 
 > For more information on network security configuration, see the [Network Architecture](./docs/network.md) documentation.
 
 ### [Optional] Uninstall / Clean-up

--- a/docs/network.md
+++ b/docs/network.md
@@ -50,7 +50,7 @@ azd up
 
 ### Network Configuration Parameters
 
-The network architecture is fully parameterized and can be customized during deployment. Organizations can modify the following parameters in `main.parameters.json` or during `azd provision`:
+The network architecture is fully parameterized and can be customized during deployment. Organizations can modify the following parameters in `main.parameters.json` or set the corresponding environment variables before running `azd up`:
 
 **VNet Configuration**:
 - `vnetName`: Custom name for the virtual network (auto-generated if not specified)
@@ -62,24 +62,47 @@ The network architecture is fully parameterized and can be customized during dep
   - `name`: Subnet name (default: `"appservice-subnet"`)
   - `addressPrefix`: Subnet address range (default: `"10.0.1.0/24"`)
   - `delegation`: Service delegation (default: `"Microsoft.Web/serverFarms"`)
-  - `serviceEndpoints`: Array of service endpoints (default: `["Microsoft.KeyVault", "Microsoft.Storage", "Microsoft.Web"]`)
+  - `serviceEndpoints`: Array of service endpoint objects with `service` and `locations` properties
   - `securityRules`: Custom NSG rules for the subnet
 
-**Example Parameter Override**:
+**Environment Variables**: Set `AZURE_VNET_NAME`, `VNET_ADDRESS_PREFIXES`, and `APPSERVICE_SUBNET_PREFIX` to customize network configuration.
+
+**Example Parameter Override for main.parameters.json**:
 ```json
-{
-  "vnetAddressPrefixes": ["172.16.0.0/16"],
-  "subnets": [
+"vnetName": {
+  "value": "${AZURE_VNET_NAME}"
+},
+"vnetAddressPrefixes": {
+  "value": ["${VNET_ADDRESS_PREFIXES}"]
+},
+"subnets": {
+  "value": [
     {
       "name": "appservice-subnet",
-      "addressPrefix": "172.16.1.0/24",
+      "addressPrefix": "${APPSERVICE_SUBNET_PREFIX}",
       "delegation": "Microsoft.Web/serverFarms",
-      "serviceEndpoints": ["Microsoft.KeyVault", "Microsoft.Storage", "Microsoft.Web"],
+      "serviceEndpoints": [
+        {
+          "service": "Microsoft.Web",
+          "locations": ["*"]
+        },
+        {
+          "service": "Microsoft.KeyVault",
+          "locations": ["*"]
+        },
+        {
+          "service": "Microsoft.Storage",
+          "locations": ["*"]
+        }
+      ],
       "securityRules": []
     }
   ]
 }
 ```
+
+> [!NOTE]
+> Copy and paste the above JSON directly into your `main.parameters.json` file to enable network customization via environment variables.
 
 > [!TIP]
 > Organizations should choose non-overlapping address spaces that align with their existing network infrastructure. The default `10.0.0.0/16` range can be modified to avoid conflicts with on-premises networks or other Azure VNets.

--- a/docs/network.md
+++ b/docs/network.md
@@ -37,6 +37,9 @@ azd env set ADDITIONAL_ALLOWED_IPS ""
 azd up
 ```
 
+> [!NOTE]
+> If you encounter any issues during redeployment, refer to the [Troubleshooting Guide](troubleshooting.md) for common issues and alternative approaches.
+
 ### Microsoft 365/Teams Integration Considerations
 
 - **IP Restriction Limitations**: The current IP-based approach covers core Teams/M365 services but has limitations with FQDN-dependent services (like `*.teams.microsoft.com`, `login.microsoft.com`). For full functionality, consider Azure Firewall with FQDN rules or the enhanced private architecture with Application Gateway.

--- a/docs/network.md
+++ b/docs/network.md
@@ -37,9 +37,6 @@ azd env set ADDITIONAL_ALLOWED_IPS ""
 azd up
 ```
 
-> [!NOTE]
-> If you encounter any issues during redeployment, refer to the [Troubleshooting Guide](troubleshooting.md) for common issues and alternative approaches.
-
 ### Microsoft 365/Teams Integration Considerations
 
 - **IP Restriction Limitations**: The current IP-based approach covers core Teams/M365 services but has limitations with FQDN-dependent services (like `*.teams.microsoft.com`, `login.microsoft.com`). For full functionality, consider Azure Firewall with FQDN rules or the enhanced private architecture with Application Gateway.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -100,7 +100,7 @@ Install-Module az.accounts
 
 If you encounter a `InUseSubnetCannotBeDeleted` error when updating IP restrictions with `azd up`, you have two options:
 1. Delete and recreate the affected resources
-2. Use Azure CLI to directly update IP restrictions without redeployment (recommended):
+2. Use Azure CLI to directly update IP restrictions without redeployment:
 
 ```bash
 # Add an IP restriction

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -93,21 +93,3 @@ You may need to install the module first with the following command
 ```powershell
 Install-Module az.accounts
 ```
-
-## Networking
-
-### Updating App Service IP Restrictions
-
-If you encounter a `InUseSubnetCannotBeDeleted` error when updating IP restrictions with `azd up`, you have two options:
-1. Delete and recreate the affected resources
-2. Use Azure CLI to directly update IP restrictions without redeployment:
-
-```bash
-# Add an IP restriction
-az webapp config access-restriction add --resource-group <your-resource-group> --name <app-name> \
-  --rule-name "AllowMyIP" --action Allow --ip-address "<your-ip>/32" --priority 200
-
-# Remove an IP restriction
-az webapp config access-restriction remove --resource-group <your-resource-group> --name <app-name> \
-  --rule-name "AllowMyIP"
-```

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -93,3 +93,21 @@ You may need to install the module first with the following command
 ```powershell
 Install-Module az.accounts
 ```
+
+## Networking
+
+### Updating App Service IP Restrictions
+
+If you encounter a `InUseSubnetCannotBeDeleted` error when updating IP restrictions with `azd up`, you have two options:
+1. Delete and recreate the affected resources
+2. Use Azure CLI to directly update IP restrictions without redeployment (recommended):
+
+```bash
+# Add an IP restriction
+az webapp config access-restriction add --resource-group <your-resource-group> --name <app-name> \
+  --rule-name "AllowMyIP" --action Allow --ip-address "<your-ip>/32" --priority 200
+
+# Remove an IP restriction
+az webapp config access-restriction remove --resource-group <your-resource-group> --name <app-name> \
+  --rule-name "AllowMyIP"
+```

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -103,7 +103,7 @@ param vnetName string = ''
 @description('Virtual network address prefixes')
 param vnetAddressPrefixes array = ['10.0.0.0/16']
 @description('Location for service endpoints')
-param serviceEndpointLocation string = resourceGroup().location
+param serviceEndpointLocation string = '*'
 @description('Subnet configurations for the virtual network')
 param subnets array = [
   {
@@ -310,8 +310,7 @@ module hlsModels 'modules/hlsModel.bicep' = if (!hasHlsModelEndpoints) {
     location: empty(hlsDeploymentLocation) ? location : hlsDeploymentLocation
     workspaceName: 'cog-ai-prj-${environmentName}-${uniqueSuffix}'
     instanceType: instanceType
-    // includeRadiologyModels: empty(healthcareAgents) ? true : !hasHealthcareAgentNeedingRadiologyModels
-    includeRadiologyModels: false
+    includeRadiologyModels: empty(healthcareAgents) ? true : !hasHealthcareAgentNeedingRadiologyModels
   }
   dependsOn: [
     m_aihub

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -102,13 +102,28 @@ var location = resourceGroup().location
 param vnetName string = ''
 @description('Virtual network address prefixes')
 param vnetAddressPrefixes array = ['10.0.0.0/16']
+@description('Location for service endpoints')
+param serviceEndpointLocation string = resourceGroup().location
 @description('Subnet configurations for the virtual network')
 param subnets array = [
   {
     name: 'appservice-subnet'
     addressPrefix: '10.0.1.0/24'
     delegation: 'Microsoft.Web/serverFarms'
-    serviceEndpoints: ['Microsoft.KeyVault', 'Microsoft.Storage', 'Microsoft.Web']
+    serviceEndpoints: [                                                            
+      {
+        service: 'Microsoft.Web'
+        locations: [serviceEndpointLocation]
+      }
+      {
+        service: 'Microsoft.KeyVault'
+        locations: [serviceEndpointLocation]
+      }
+      {
+        service: 'Microsoft.Storage'
+        locations: [serviceEndpointLocation]
+      }
+    ]
     securityRules: [
       {
         name: 'AllowHTTPSInbound'
@@ -295,7 +310,8 @@ module hlsModels 'modules/hlsModel.bicep' = if (!hasHlsModelEndpoints) {
     location: empty(hlsDeploymentLocation) ? location : hlsDeploymentLocation
     workspaceName: 'cog-ai-prj-${environmentName}-${uniqueSuffix}'
     instanceType: instanceType
-    includeRadiologyModels: empty(healthcareAgents) ? true : !hasHealthcareAgentNeedingRadiologyModels
+    // includeRadiologyModels: empty(healthcareAgents) ? true : !hasHealthcareAgentNeedingRadiologyModels
+    includeRadiologyModels: false
   }
   dependsOn: [
     m_aihub

--- a/infra/modules/network.bicep
+++ b/infra/modules/network.bicep
@@ -11,7 +11,28 @@ param vnetName string
 param vnetAddressPrefixes array = ['10.0.0.0/16']
 
 @description('Subnet configurations for the virtual network')
-param subnets array
+param subnets array = [
+  {
+    name: 'appservice-subnet'
+    addressPrefix: '10.0.1.0/24'
+    delegation: 'Microsoft.Web/serverFarms'
+    serviceEndpoints: [
+      {
+        service: 'Microsoft.Web'
+        locations: ['*']
+      }
+      {
+        service: 'Microsoft.KeyVault'
+        locations: ['*']
+      }
+      {
+        service: 'Microsoft.Storage'
+        locations: ['*']
+      }
+    ]
+    securityRules: []
+  }
+]
 
 @description('Tags for network resources')
 param tags object = {}

--- a/infra/modules/network.bicep
+++ b/infra/modules/network.bicep
@@ -43,38 +43,33 @@ resource vnet 'Microsoft.Network/virtualNetworks@2023-09-01' = {
     addressSpace: {
       addressPrefixes: vnetAddressPrefixes
     }
+    subnets: [
+      for (subnet, i) in subnets: {
+        name: subnet.name
+        properties: {
+          addressPrefix: subnet.addressPrefix
+          networkSecurityGroup: {
+            id: nsg[i].id
+          }
+          delegations: subnet.delegation != '' ? [
+            {
+              name: subnet.delegation
+              properties: {
+                serviceName: subnet.delegation
+              }
+            }
+          ] : []
+          serviceEndpoints: subnet.serviceEndpoints
+        }
+      }
+    ]
   }
 }
 
-// Subnets
-resource subnet 'Microsoft.Network/virtualNetworks/subnets@2023-09-01' = [for (subnet, i) in subnets: {
-  parent: vnet
-  name: subnet.name
-  properties: {
-    addressPrefix: subnet.addressPrefix
-    networkSecurityGroup: {
-      id: nsg[i].id
-    }
-    delegations: subnet.delegation != '' ? [
-      {
-        name: subnet.delegation
-        properties: {
-          serviceName: subnet.delegation
-        }
-      }
-    ] : []
-    serviceEndpoints: [for endpoint in subnet.serviceEndpoints: {
-      service: endpoint
-      locations: [
-        location
-      ]
-    }]
-  }
-}]
-
 output vnetId string = vnet.id
 output vnetName string = vnet.name
-output subnetIds array = [for i in range(0, length(subnets)): subnet[i].id]
+output subnetIds array = [for i in range(0, length(subnets)): '${vnet.id}/subnets/${subnets[i].name}']
 output subnetNames array = [for subnet in subnets: subnet.name]
-output appServiceSubnetId string = subnet[0].id // First subnet is assumed to be app service subnet
+output appServiceSubnetId string = '${vnet.id}/subnets/${subnets[0].name}' // First subnet is assumed to be app service subnet
 output nsgIds array = [for i in range(0, length(subnets)): nsg[i].id]
+

--- a/infra/modules/network.bicep
+++ b/infra/modules/network.bicep
@@ -11,15 +11,7 @@ param vnetName string
 param vnetAddressPrefixes array = ['10.0.0.0/16']
 
 @description('Subnet configurations for the virtual network')
-param subnets array = [
-  {
-    name: 'appservice-subnet'
-    addressPrefix: '10.0.1.0/24'
-    delegation: 'Microsoft.Web/serverFarms'
-    serviceEndpoints: ['Microsoft.KeyVault', 'Microsoft.Storage', 'Microsoft.Web']
-    securityRules: []
-  }
-]
+param subnets array
 
 @description('Tags for network resources')
 param tags object = {}


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
Fixed VNet/subnet redeployment issue: Resolved deployment errors that occurred when trying to update ADDITIONAL_ALLOWED_IPS after initial VNet and subnet creation
Optimized service endpoint configuration: Changed service endpoint locations from region-specific to "*" (global) to prevent deployment conflicts during updates

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[ x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
Redeploy the new network changes and test using msft teams or with the healthcare agent orchestrator ui . 

```

## What to Check
Verify that the following are valid

Primary fix: VNet/subnet redeployment works without errors when updating ADDITIONAL_ALLOWED_IPS
Service endpoints use global locations ("*") for multi-region flexibility


## Other Information
<!-- Add any other helpful information that may be needed here. -->

This fix enables users to iteratively update IP allowlists and other network configurations without redeploying the entire infrastructure