### PR TITLE
Fix manifest parsing error in Teams

### DIFF
--- a/scripts/generateTeamsApp.ps1
+++ b/scripts/generateTeamsApp.ps1
@@ -60,7 +60,9 @@ foreach ($bot in $azureBotsContent) {
     $manifestContent.description.full = $bot.name    
     $manifestContent.icons.color = $bot.name + ".png"
     $manifestContent.icons.outline = $bot.name + ".png"
-
+    $manifestContent.webApplicationInfo.id = $bot.botId
+    $manifestContent.webApplicationInfo.resource = "api://botid-$($bot.botId)"
+    
     # Define the new manifest file path
     $newManifestFilePath = Join-Path -Path $botOutputDirectory -ChildPath "manifest.json"
 

--- a/scripts/generateTeamsApp.sh
+++ b/scripts/generateTeamsApp.sh
@@ -78,7 +78,9 @@ echo "$azureBotsContent" | while IFS= read -r bot; do
         .description.short = $botName |
         .description.full = $botName |
         .icons.outline = ($botName + ".png")  |
-        .icons.color = ($botName + ".png") 
+        .icons.color = ($botName + ".png") |
+        .webApplicationInfo.id = $botId |
+        .webApplicationInfo.resource = "api://botid-$botId"
     ')
 
     # Define the new manifest file path

--- a/teamsApp/manifest.json
+++ b/teamsApp/manifest.json
@@ -10,7 +10,7 @@
     "developer": {
         "name": "Microsoft",
         "mpnId": "",
-        "websiteUrl": "https://microsoft.comg",
+        "websiteUrl": "https://microsoft.com",
         "privacyUrl": "https://microsoft.com",
         "termsOfUseUrl": "https://microsoft.com"
     },
@@ -80,5 +80,9 @@
         "privateChannels",
         "sharedChannels"
     ],
-    "configurableTabs": []
+    "configurableTabs": [],
+    "webApplicationInfo": {
+        "id": "",
+        "resource": ""
+    }
 }


### PR DESCRIPTION
## Purpose
Users reported they're getting errors when adding agents in Teams.  I was able to reproduce the parsing errors.

When uploading the agent zip file in Teams:

<img width="883" height="882" alt="image" src="https://github.com/user-attachments/assets/05dd2d0f-185e-457f-8510-3708121bbed1" />

When running `scripts\uploadPackage.ps1`,

<img width="737" height="77" alt="image" src="https://github.com/user-attachments/assets/5373d984-9626-49e7-bec3-3d1a3cb27455" />


## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code from branch `frank/manifest`
*  Run `azd provision`
* 
## What to Check
Install a zip file from the `output` folder, such as `PatientHistory.zip`.  You should not see the parsing error reported by users.  Agent can be installed successfully.