### PR TITLE
Fixing manifest schema for teams app generation

### DIFF
--- a/teamsApp/manifest.json
+++ b/teamsApp/manifest.json
@@ -61,16 +61,6 @@
     },
     "authorization": {
         "permissions": {
-            "resourceSpecific": [
-                {
-                    "name": "ChatMessage.Send.Chat",
-                    "type": "Application"
-                },
-                {
-                    "name": "ChatMessage.Read.Chat",
-                    "type": "Application"
-                }
-            ]
         }
     },
     "activities": {


### PR DESCRIPTION
## Purpose
Recent teams schema changes cause an issue in how we generate the teams zip package.
We don't actually use resource specific consent for side-loaded applications. Removing the permission section fixes the issue.


## Does this introduce a breaking change?
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
Run azd up, then upload the agents to a chat
